### PR TITLE
Refactor public API to work with keyset

### DIFF
--- a/lib/graphql/connections.rb
+++ b/lib/graphql/connections.rb
@@ -8,8 +8,10 @@ module GraphQL
   end
 end
 
-require "graphql/connections/base"
 require "graphql/connections/stable"
+
+require "graphql/connections/base"
+require "graphql/connections/key"
 
 require "graphql/connections/keyset/base"
 require "graphql/connections/keyset/asc"

--- a/lib/graphql/connections/key.rb
+++ b/lib/graphql/connections/key.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Connections
+    # Cursor-based pagination to work with `ActiveRecord::Relation`s.
+    # Implements a mechanism for serving stable connections based on column values.
+    # If objects are created or destroyed during pagination, the list of items won't be disrupted.
+    #
+    # Inspired by `GraphQL::Pro`s Stable Relation Connections
+    # https://graphql-ruby.org/pagination/stable_relation_connections.html
+    #
+    # For more information see GraphQL Cursor Connections Specification
+    # https://relay.dev/graphql/connections.htm
+    class Key < ::GraphQL::Connections::Base
+      def initialize(*args, primary_key: nil, **kwargs)
+        @primary_key = primary_key
+
+        super(*args, **kwargs)
+      end
+
+      def has_previous_page # rubocop:disable Naming/PredicateName
+        if last
+          nodes.any? && items.where(arel_table[primary_key].lt(nodes.first[primary_key])).exists?
+        elsif after
+          items.where(arel_table[primary_key].lteq(after_cursor)).exists?
+        else
+          false
+        end
+      end
+
+      def has_next_page # rubocop:disable Naming/PredicateName
+        if first
+          nodes.any? && items.where(arel_table[primary_key].gt(nodes.last[primary_key])).exists?
+        elsif before
+          items.where(arel_table[primary_key].gteq(before_cursor)).exists?
+        else
+          false
+        end
+      end
+
+      def cursor_for(item)
+        cursor = serialize(item[primary_key])
+        cursor = encode(cursor) if opaque_cursor
+        cursor
+      end
+
+      private
+
+      def limited_relation
+        scope = sliced_relation
+        nodes = []
+
+        if first
+          nodes |= scope.
+                   reorder(arel_table[primary_key].asc).
+                   limit(first).
+                   to_a
+        end
+
+        if last
+          nodes |= scope.
+                   reorder(arel_table[primary_key].desc).
+                   limit(last).
+                   to_a.reverse!
+        end
+
+        nodes
+      end
+
+      def sliced_relation
+        items.
+          yield_self { |s| after ? s.where(arel_table[primary_key].gt(after_cursor)) : s }.
+          yield_self { |s| before ? s.where(arel_table[primary_key].lt(before_cursor)) : s }
+      end
+    end
+  end
+end

--- a/lib/graphql/connections/keyset/base.rb
+++ b/lib/graphql/connections/keyset/base.rb
@@ -8,9 +8,8 @@ module GraphQL
 
         SEPARATOR = '/'
 
-        def initialize(*args, field_key: nil, primary_key: nil, separator: SEPARATOR, **kwargs)
-          @primary_key = primary_key
-          @field_key = field_key
+        def initialize(*args, keys:, separator: SEPARATOR, **kwargs)
+          @field_key, @primary_key = keys
           @separator = separator
 
           super(*args, **kwargs)

--- a/lib/graphql/connections/stable.rb
+++ b/lib/graphql/connections/stable.rb
@@ -11,66 +11,17 @@ module GraphQL
     #
     # For more information see GraphQL Cursor Connections Specification
     # https://relay.dev/graphql/connections.htm
-    class Stable < ::GraphQL::Connections::Base
-      def initialize(*args, primary_key: nil, **kwargs)
-        @primary_key = primary_key
-
-        super(*args, **kwargs)
-      end
-
-      def has_previous_page # rubocop:disable Naming/PredicateName
-        if last
-          nodes.any? && items.where(arel_table[primary_key].lt(nodes.first[primary_key])).exists?
-        elsif after
-          items.where(arel_table[primary_key].lteq(after_cursor)).exists?
-        else
-          false
-        end
-      end
-
-      def has_next_page # rubocop:disable Naming/PredicateName
-        if first
-          nodes.any? && items.where(arel_table[primary_key].gt(nodes.last[primary_key])).exists?
-        elsif before
-          items.where(arel_table[primary_key].gteq(before_cursor)).exists?
-        else
-          false
-        end
-      end
-
-      def cursor_for(item)
-        cursor = serialize(item[primary_key])
-        cursor = encode(cursor) if opaque_cursor
-        cursor
-      end
-
-      private
-
-      def limited_relation
-        scope = sliced_relation
-        nodes = []
-
-        if first
-          nodes |= scope.
-                   reorder(arel_table[primary_key].asc).
-                   limit(first).
-                   to_a
+    class Stable
+      def self.new(*args, desc: false, keys: nil, **kwargs)
+        if kwargs[:primary_key] || keys.nil?
+          raise NotImplementedError, 'desc connection is not implemented yet' if desc
+          return GraphQL::Connections::Key.new(*args, **kwargs)
         end
 
-        if last
-          nodes |= scope.
-                   reorder(arel_table[primary_key].desc).
-                   limit(last).
-                   to_a.reverse!
-        end
+        raise ArgumentError, 'keyset for more that 2 keys is not implemented yet' if keys.length > 2
 
-        nodes
-      end
-
-      def sliced_relation
-        items.
-          yield_self { |s| after ? s.where(arel_table[primary_key].gt(after_cursor)) : s }.
-          yield_self { |s| before ? s.where(arel_table[primary_key].lt(before_cursor)) : s }
+        klass = desc ? GraphQL::Connections::Keyset::Desc : GraphQL::Connections::Keyset::Asc
+        klass.new(*args, **kwargs)
       end
     end
   end

--- a/spec/lib/key_spec.rb
+++ b/spec/lib/key_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe GraphQL::Connections::Stable do
+describe GraphQL::Connections::Key do
   let_it_be(:msg_a) { Message.create!(body: "A", created_at: Time.local(2020, 10, 2, 15)) }
   let_it_be(:msg_b) { Message.create!(body: "B", created_at: Time.local(2020, 10, 2, 14)) }
   let_it_be(:msg_c) { Message.create!(body: "C", created_at: Time.local(2020, 10, 2, 13)) }

--- a/spec/lib/keyset/asc_spec.rb
+++ b/spec/lib/keyset/asc_spec.rb
@@ -12,8 +12,8 @@ describe GraphQL::Connections::Keyset::Asc do
   let(:schema) { ApplicationSchema }
   let(:context) { instance_double(GraphQL::Query::Context, schema: schema) }
   let(:relation) { Message.all }
-  let(:base_connection) { described_class.new(Message.none, field_key: :body, context: context) }
-  let(:connection) { described_class.new(relation, field_key: :body, context: context, **params) }
+  let(:base_connection) { described_class.new(Message.none, keys: [:body], context: context) }
+  let(:connection) { described_class.new(relation, keys: [:body], context: context, **params) }
   let(:nodes) { connection.nodes }
   let(:names) { nodes.map(&:body) }
 

--- a/spec/lib/keyset/desc_spec.rb
+++ b/spec/lib/keyset/desc_spec.rb
@@ -12,8 +12,8 @@ describe GraphQL::Connections::Keyset::Desc do
   let(:schema) { ApplicationSchema }
   let(:context) { instance_double(GraphQL::Query::Context, schema: schema) }
   let(:relation) { Message.all }
-  let(:base_connection) { described_class.new(Message.none, field_key: :body, context: context) }
-  let(:connection) { described_class.new(relation, field_key: :body, context: context, **params) }
+  let(:base_connection) { described_class.new(Message.none, keys: [:body], context: context) }
+  let(:connection) { described_class.new(relation, keys: [:body], context: context, **params) }
   let(:nodes) { connection.nodes }
   let(:names) { nodes.map(&:body) }
 


### PR DESCRIPTION
# Context

Refactored API to support keyset. I imagine the following API:

```
GraphQL::Connections::Stable.new(Message.all) -> Key
GraphQL::Connections::Stable.new(Message.all, primary_key: :created_at) -> Key
GraphQL::Connections::Stable.new(Message.all, desc: true) -> NotImplementedError
GraphQL::Connections::Stable.new(Message.all, keys: [:body]) -> Keyset::Asc for body+primary_key
GraphQL::Connections::Stable.new(Message.all, keys: [:body, :id]) -> Keyset::Asc for body+id
GraphQL::Connections::Stable.new(Message.all, keys: [:body], desc: true) -> Keyset::Desc for body+primary_key
```

Please let me know if you want to make it different.

# Checklist:

- [ ] I have added tests
- [ ] I have made corresponding changes to the documentation
